### PR TITLE
Update action.yml with unique name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: 'Licensed CI'
-description: 'Ensure cached github/licensed license data is valid and up to date'
+name: 'Licensed CI (for licensee/licensed)'
+description: 'Ensure cached licensee/licensed license data is valid and up to date'
 inputs:
   command:
     description: 'Licensed command to run'


### PR DESCRIPTION
The "Licensed CI" name is used by the github/licensed-ci action, so we need a new unique name.