### PR TITLE
Add missing commas in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ jobs:
           script: |
             github.issues.createComment({
               ...context.repo,
-              issue_number: ${{ steps.licensed.outputs.pr_number }}
+              issue_number: ${{ steps.licensed.outputs.pr_number }},
               body: 'My custom PR message'
             })
 ```
@@ -237,7 +237,7 @@ jobs:
           script: |
             github.issues.createComment({
               ...context.repo,
-              issue_number: ${{ steps.licensed.outputs.pr_number }}
+              issue_number: ${{ steps.licensed.outputs.pr_number }},
               body: 'My custom PR message'
             })
 ```


### PR DESCRIPTION
This updates the README by adding missing commas in the `actions/github-script` examples. Without it, I experienced this stack trace which is a little misleading:

```
SyntaxError: Unexpected identifier 'body'
    at new AsyncFunction (<anonymous>)
    at callAsyncFunction (/home/runner/work/_actions/actions/github-script/v7/dist/index.js:35424:16)
    at main (/home/runner/work/_actions/actions/github-script/v7/dist/index.js:35522:26)
    at /home/runner/work/_actions/actions/github-script/v7/dist/index.js:35497:1
    at /home/runner/work/_actions/actions/github-script/v7/dist/index.js:35553:3
    at Object.<anonymous> (/home/runner/work/_actions/actions/github-script/v7/dist/index.js:35556:12)
    at Module._compile (node:internal/modules/cjs/loader:1469:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1548:10)
    at Module.load (node:internal/modules/cjs/loader:1288:[32](https://github.com/wearethorn/hash-matcher/actions/runs/13208329523/job/36876643340#step:16:33))
    at Module._load (node:internal/modules/cjs/loader:1104:12)
```

---

Hi 👋 I just wanted to say thanks for this GitHub Action!