### PR TITLE
Run Dependabot on Friday

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ multi-ecosystem-groups:
   all:
     schedule:
       interval: weekly
-      day: "monday"
+      day: "friday"
       time: "08:00"
       timezone: "Etc/UTC"
 


### PR DESCRIPTION
- Avoid Monday dependency noise by moving the weekly run
- Keep the existing shared Dependabot group and UTC time